### PR TITLE
Fix typo error section 1 - lesson 3

### DIFF
--- a/Solidity_And_Smart_Contracts/pt-BR/Section_1/Lesson_3_Compile_Contract_Locally.md
+++ b/Solidity_And_Smart_Contracts/pt-BR/Section_1/Lesson_3_Compile_Contract_Locally.md
@@ -62,7 +62,7 @@ const waveContractFactory = await hre.ethers.getContractFactory("WavePortal");
 Esse trecho compilará nosso contrato e gerará os arquivos necessários que precisamos para trabalhar com nosso contrato no diretório `artefatos`. Vá dar uma olhada depois que colocar para executar :).
 
 ```javascript
-const waveContract = await waveContractFactory.deploy();
+const waveContract = await waveContractFactory.deployed();
 ```
 
 Isso é bem maneiro :).


### PR DESCRIPTION
Identifiquei esse erro de digitação do seguinte script `await waveContract.deployed();` que gera um erro ao ser executado da forma como está descrito `await waveContract.deploy();.`