### PR TITLE
Fix Lesson 4 const to export default function as it was used before

### DIFF
--- a/Solidity_And_Smart_Contracts/pt-BR/Section_2/Lesson_4_Call_Deployed_Contract.md
+++ b/Solidity_And_Smart_Contracts/pt-BR/Section_2/Lesson_4_Call_Deployed_Contract.md
@@ -96,7 +96,7 @@ import React, { useEffect, useState } from "react";
 import { ethers } from "ethers";
 import "./App.css";
 
-const App = () => {
+export default function App() {
   const [currentAccount, setCurrentAccount] = useState("");
   /**
    * Cria uma variável para guardar o endereço do contrato após o deploy!


### PR DESCRIPTION
Some of the students were struggling around this because they were copy pasting and it was overriding the export default function to a const that was never exported. 