### PR TITLE
Correct typos and suggest changes

### DIFF
--- a/NFT_Collection/pt-br/Section_1/Lesson_1_What_Is_A_NFT.md
+++ b/NFT_Collection/pt-br/Section_1/Lesson_1_What_Is_A_NFT.md
@@ -2,17 +2,17 @@
 
 Eu vi tantos tutoriais complicarem isso. Então, vou tentar manter a explicação simples :).
 
-Um NFT é um "token" que uma pessoa pode possuir que liga a algum "dado" (exemplo. liga a uma arte digital, a um vídeo, imagem, etc). O truque com NFTs é que cada "token" tem um identificador único, que confere ao dono o poder de provar que o NFT é único. Vamos ver o código depois :).
+Um NFT é um "token" que uma pessoa pode possuir que liga a algum "dado" (por exemplo, liga a uma arte digital, a um vídeo, imagem, etc). O truque com NFTs é que cada "token" tem um identificador único, que confere ao dono o poder de provar que o NFT é único. Vamos ver o código depois :).
 
 Vamos passar por um exemplo rapidamente.
 
 ## 🎨 Esboços de Picasso
 
-Digamos que Picasso queria criar uma coleção de 100 de seus esboços para vender.
+Digamos que Picasso quisesse criar uma coleção de 100 de seus esboços para vender.
 
-Sabemos que cada esboço é único, porque podemos ver um lápis físico desenhando. Logo, é óbvio que Picasso não apenas fez várias cópias de seus desenhos.
+Sabemos que cada esboço é único, porque podemos ver um lápis físico desenhando. Logo, é óbvio que Picasso não fez apenas várias cópias de seus desenhos.
 
-Também sabemos que Picasso que desenhou os esboços. Como? Bem - porque Picasso disse que desenhou e assinou-os! Você pode comprar esse esboço original de Picasso agora e ter a certificação de que você tem um "Original Picasso", da galeria que Picasso os vendeu.
+Também sabemos que Picasso que desenhou os esboços. Como? Bem - porque Picasso disse que desenhou e assinou-os! Você pode comprar esse esboço original de Picasso agora e ter a certificação de que você tem um "Picasso Original", da galeria que Picasso os vendeu.
 
 Você precisa confiar que o certificado da galeria será respeitado a longo prazo, mas, no geral, isso é fácil!
 
@@ -22,26 +22,26 @@ Você precisa confiar que o certificado da galeria será respeitado a longo praz
 
 Vamos dar uma olhada nesse exemplo no **Mundo NFT** agora.
 
-Digamos que picasso queria criar uma coleção de 100 de seus esboços, onde cada esboço é uma **arte digital**, como um arquivo JPEG.
+Digamos que Picasso quisisse criar uma coleção de 100 de seus esboços, onde cada esboço é uma **arte digital**, como um arquivo JPEG.
 
 Picasso iria criar sua coleção NFT construindo (programando) seu "smart contract" (contrato inteligente), onde o código roda toda a lógica para sua coleção NFT.
 
-Ele daria a cada arte um identificador único (ex. Esboço #1, Esboço #2, Esboço #3, etc). Então, quando Picasso estiver pronto para "lançar" sua coleção NFT ele a lançaria usando sua própria carteira Ethereum para "assinar" a coleção NFT. Quando ele estivesse pronto, colocaria na blockchain publicamente - onde todos podem ver publicamente a coleção NFT de Picasso.
+Ele daria a cada arte um identificador único (ex. Esboço #1, Esboço #2, Esboço #3, etc). Então, quando Picasso estiver pronto para "lançar" sua coleção NFT, ele a lançaria usando sua própria carteira Ethereum para "assinar" a coleção NFT. Quando ele estivesse pronto, colocaria publicamente na blockchain  - onde todos podem ver publicamente a coleção NFT de Picasso.
 
-Então, quando Picasso quiser vender uma das NFTs, tudo o que ele precisa fazer é "transferir" a NFT para a pessoa que comprou usando o endereço público da carteira do comprador.
+Então, quando Picasso quiser vender um dos NFTs, tudo o que ele precisa fazer é "transferir" o NFT para a pessoa que comprou usando o endereço público da carteira do comprador.
 
-A pessoa que comprou o NFT ficará feliz, porque conseguiu a **única e original, obra de Picasso! Do próprio Picasso!** E a melhor parte? Ele pode provar!
+A pessoa que comprou o NFT ficará feliz, porque conseguiu a, **única e original, obra de Picasso! Do próprio Picasso!** E a melhor parte? Ela pode provar!
 
 Como?
 
-1. O comprador pode provar que a coleção NFT foi originalmente assinada e criado por Picasso, porque a NFT mostraria que veio de um contrato inteligente assinado por Picasso. Lembre-se, Picasso assinou a coleção com seu endereço público! Geralmente, artistas anunciam publicamente o endereço de suas carteiras para que ninguém possa fingir ser eles.
+1. O comprador pode provar que a coleção NFT foi originalmente assinada e criada por Picasso, porque a NFT mostraria que veio de um contrato inteligente assinado por Picasso. Lembre-se, Picasso assinou a coleção com seu endereço público! Geralmente, artistas anunciam publicamente o endereço de suas carteiras para que ninguém possa fingir ser eles.
 
-2. O comprador pode provar porque a NFT é um esboço único de Picasso de sua coleção pois cada NFT da coleção tem um identificador único (ex. Esboço #1, Esboço #2, Esboço #3, etc) e isso vem da pessoa que originalmente criou a coleção.
+2. O comprador pode provar porque o NFT é um esboço único de Picasso de sua coleção pois cada NFT da coleção tem um identificador único (por exemplo, Esboço #1, Esboço #2, Esboço #3, etc) e isso vem da pessoa que originalmente criou a coleção.
 
 Ok, então, espero que isso faça **algum sentido**.
 
 Esse é um conceito extremamente poderoso - a ideia de que qualquer arquivo pode ser feito único e valioso é incrível. Também é por isso que você pode estar vendo o Twitter indo a loucura sobre NFTs ultimamente. NFTs já estão mexendo com a arte, os jogos, e mais.
 
-Eu não espero que você entenda profundamente ainda. Se não fizer nenhum sentido, talvez leia de novo! Mas tenha certeza que faça **algum sentido** antes de sair. Eu só quero te dar uma pequena base de conhecimento.
+Eu não espero que você entenda profundamente ainda. Se não fizer nenhum sentido, talvez leia de novo! Mas tenha certeza que faça **algum sentido** antes de continuar. Eu só quero te dar uma pequena base de conhecimento.
 
 Geralmente, eu começo a entender realmente as coisas quando começo a programar. Então, vamos ajeitar o nosso ambiente local e entrar em algum código :).

--- a/NFT_Collection/pt-br/Section_1/Lesson_1_What_Is_A_NFT.md
+++ b/NFT_Collection/pt-br/Section_1/Lesson_1_What_Is_A_NFT.md
@@ -1,8 +1,8 @@
-# O que é um NFT
+# O que é uma NFT
 
 Eu vi tantos tutoriais complicarem isso. Então, vou tentar manter a explicação simples :).
 
-Um NFT é um "token" que uma pessoa pode possuir que liga a algum "dado" (por exemplo, liga a uma arte digital, a um vídeo, imagem, etc). O truque com NFTs é que cada "token" tem um identificador único, que confere ao dono o poder de provar que o NFT é único. Vamos ver o código depois :).
+Uma NFT é um "token" que uma pessoa pode possuir que liga a algum "dado" (por exemplo, liga a uma arte digital, a um vídeo, imagem, etc). O truque com NFTs é que cada "token" tem um identificador único, que confere ao dono o poder de provar que o NFT é único. Vamos ver o código depois :).
 
 Vamos passar por um exemplo rapidamente.
 
@@ -28,15 +28,15 @@ Picasso iria criar sua coleção NFT construindo (programando) seu "smart contra
 
 Ele daria a cada arte um identificador único (ex. Esboço #1, Esboço #2, Esboço #3, etc). Então, quando Picasso estiver pronto para "lançar" sua coleção NFT, ele a lançaria usando sua própria carteira Ethereum para "assinar" a coleção NFT. Quando ele estivesse pronto, colocaria publicamente na blockchain  - onde todos podem ver publicamente a coleção NFT de Picasso.
 
-Então, quando Picasso quiser vender um dos NFTs, tudo o que ele precisa fazer é "transferir" o NFT para a pessoa que comprou usando o endereço público da carteira do comprador.
+Então, quando Picasso quiser vender uma das NFTs, tudo o que ele precisa fazer é "transferir" a NFT para a pessoa que comprou usando o endereço público da carteira do comprador.
 
-A pessoa que comprou o NFT ficará feliz, porque conseguiu a, **única e original, obra de Picasso! Do próprio Picasso!** E a melhor parte? Ela pode provar!
+A pessoa que comprou a NFT ficará feliz, porque conseguiu a, **única e original, obra de Picasso! Do próprio Picasso!** E a melhor parte? Ela pode provar!
 
 Como?
 
 1. O comprador pode provar que a coleção NFT foi originalmente assinada e criada por Picasso, porque a NFT mostraria que veio de um contrato inteligente assinado por Picasso. Lembre-se, Picasso assinou a coleção com seu endereço público! Geralmente, artistas anunciam publicamente o endereço de suas carteiras para que ninguém possa fingir ser eles.
 
-2. O comprador pode provar porque o NFT é um esboço único de Picasso de sua coleção pois cada NFT da coleção tem um identificador único (por exemplo, Esboço #1, Esboço #2, Esboço #3, etc) e isso vem da pessoa que originalmente criou a coleção.
+2. O comprador pode provar porque a NFT é um esboço único de Picasso de sua coleção pois cada NFT da coleção tem um identificador único (por exemplo, Esboço #1, Esboço #2, Esboço #3, etc) e isso vem da pessoa que originalmente criou a coleção.
 
 Ok, então, espero que isso faça **algum sentido**.
 


### PR DESCRIPTION
- Fix typos
- Uniforms the translation of the acronym NFT for the male gender
- Changes the tense of some verbs to "pretérito imperfeito do subjuntivo"