### PR TITLE
Update Lesson_3_Deploy_NFTs_To_Devnet.md

### DIFF
--- a/Solana_NFTs/pt_br/Section_2/Lesson_3_Deploy_NFTs_To_Devnet.md
+++ b/Solana_NFTs/pt_br/Section_2/Lesson_3_Deploy_NFTs_To_Devnet.md
@@ -57,7 +57,7 @@ Depois disso, você pode executar `solana balance` novamente e pronto, você ter
 Para obter o endereço de sua carteira execute o comando:
 
 ```bash
-solana adress
+solana address
 ```
 
 O endereço de sua carteira será usado logo abaixo.


### PR DESCRIPTION
Alterado "solana adress" para "solana address" devido informação de erro no terminal: "error: The subcommand 'adress' wasn't recognized
        Did you mean 'address'?

If you believe you received this message in error, try re-running with 'solana -- adress'

USAGE:
    solana [FLAGS] [OPTIONS] <SUBCOMMAND>

For more information try --help"