### PR TITLE
Faltou o await no tokenModule

### DIFF
--- a/JS_DAO/pt-br/Section_4/Lesson_1_Remova_Seus_Poderes_de_Admin_e_Erros_Basicos.md
+++ b/JS_DAO/pt-br/Section_4/Lesson_1_Remova_Seus_Poderes_de_Admin_e_Erros_Basicos.md
@@ -9,7 +9,7 @@ Dessa maneira, apenas o contrato de votação é capaz de cunhar novos tokens. N
 ```jsx
 import sdk from "./1-initialize-sdk.js";
 
-const tokenModule = sdk.getTokenModule(
+const tokenModule = await sdk.getTokenModule(
   "INSIRA_O_ENDEREÇO_DO_TOKEN_MODULE",
 );
 


### PR DESCRIPTION
# [LINK DA LIÇÃO COM ERRO](https://bootcamp.web3dev.com.br/courses/JS_DAO/lessons/Lesson_1_Remove_Admin_Power_And_Basic_Errors.md)
 
# FIX DO ERRO
No código da Seção 4 da JS_DAO não havia await
``` jsx
const token = await sdk.getContract("CONTRATO_TOKEN", "token");
```


![image](https://user-images.githubusercontent.com/107029851/222025618-04c6b30f-a5a4-4ec5-9cd3-ebc3081e896f.png)
