### PR TITLE
Rust_State_Machine: Fix 2.1 video link + minor typos

### DIFF
--- a/Rust_State_Machine/en/Section_2/Lesson_1_System_Pallet.md
+++ b/Rust_State_Machine/en/Section_2/Lesson_1_System_Pallet.md
@@ -10,7 +10,7 @@ Then you will integrate both the Balances Pallet and System Pallet into your sta
 
 # Introduce the System Pallet
 
-[Youtube](https://www.youtube.com/watch?v=ROioE9Tlrmc)
+[Youtube](https://www.youtube.com/watch?v=8Tyhf6jtHpI)
 
 We have basically completed the creation of a basic Balances Pallet. This is the pallet that most users will interact with.
 

--- a/Rust_State_Machine/en/Section_4/Lesson_4_Dispatching_Calls.md
+++ b/Rust_State_Machine/en/Section_4/Lesson_4_Dispatching_Calls.md
@@ -28,7 +28,7 @@ So when adding a new variant to `RuntimeCall`, it should look something like:
 
 ```rust
 pub enum RuntimeCall {
-	BalancesTransfer { to: types::AccountId, amount: types;:Balance },
+	BalancesTransfer { to: types::AccountId, amount: types::Balance },
 }
 ```
 

--- a/Rust_State_Machine/en/Section_4/Lesson_6_Pallet_Level_Dispatch.md
+++ b/Rust_State_Machine/en/Section_4/Lesson_6_Pallet_Level_Dispatch.md
@@ -8,7 +8,7 @@ We want to make our code more modular and extensible.
 
 Currently, all dispatch happens through the `RuntimeCall`, which is hardcoding dispatch logic for each of the Pallets in our system.
 
-What we would prefer is for Pallet level dispatch logic to live in the Pallet itself, and our Runtime taking advantage of that. We ave already seen end to end what it takes to set up call dispatch, so let's do it again at the Pallet level.
+What we would prefer is for Pallet level dispatch logic to live in the Pallet itself, and our Runtime taking advantage of that. We have already seen end to end what it takes to set up call dispatch, so let's do it again at the Pallet level.
 
 ## Pallet Call
 


### PR DESCRIPTION
Rust_State_Machine

- Fix 2.1 video link
- Fix 4.4 small typo in the enum code
- Fix 4.6 small typo

> Ps. Please let me know if I need to sync the change in any other active branch.

Thankss