### PR TITLE
Fixed balance assertions using references

### DIFF
--- a/Rust_State_Machine/en/Section_1/Lesson_4_Basic_Tests.md
+++ b/Rust_State_Machine/en/Section_1/Lesson_4_Basic_Tests.md
@@ -33,10 +33,10 @@ For that, we will go back to the `main.rs` file, and create our first `#[test]` 
 	fn init_balances() {
 		let mut balances = balances::Pallet::new();
 
-		assert_eq!(balances.balance("alice".to_string()), 0);
-		balances.set_balance("alice".to_string(), 100);
-		assert_eq!(balances.balance("alice".to_string()), 100);
-		assert_eq!(balances.balance("bob".to_string()), 0);
+		assert_eq!(balances.balance(&"alice".to_string()), 0);
+		balances.set_balance(&"alice".to_string(), 100);
+		assert_eq!(balances.balance(&"alice".to_string()), 100);
+		assert_eq!(balances.balance(&"bob".to_string()), 0);
 	}
 	```
 


### PR DESCRIPTION
In [Lesson 4](https://build.w3d.community/courses/Rust_State_Machine/Section_1/Lesson_4_Basic_Tests.md?lang=en) of Section 1, we have used assertions to check for the user balances but there's a slight error as `references` aren't used for those strings. Here's a glimpse of it:

![image](https://github.com/user-attachments/assets/e4f9463a-a662-47d9-9dd7-890aea9c1c42)

Here's the fix that has been made:

![image](https://github.com/user-attachments/assets/1a2a1980-a4fa-49d3-9b02-26606bdaf9e2)